### PR TITLE
Add modern browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+last 2 Chrome versions
+last 2 Firefox versions
+last 2 Safari versions
+last 2 Edge versions


### PR DESCRIPTION
## Summary
- set Browserslist to modern versions only to avoid unnecessary transpilation

## Testing
- `yarn js-lint-src`
- `yarn test` *(fails: command not found: jest)*

------
https://chatgpt.com/codex/tasks/task_e_688892b1d1288329887a6850371b6911