### PR TITLE
Use dynamic imports for Tiptap editors

### DIFF
--- a/components/statements/custom_editor/citation_node_editor.tsx
+++ b/components/statements/custom_editor/citation_node_editor.tsx
@@ -4,7 +4,12 @@ import { Editor } from '@tiptap/react';
 
 import { useStatementToolsContext } from '@/contexts/StatementToolsContext';
 
-import { CitationPopover } from './citation_popover';
+import dynamic from 'next/dynamic';
+
+const CitationPopover = dynamic(
+  () => import('./citation_popover').then(mod => mod.CitationPopover),
+  { ssr: false }
+);
 interface CitationNodeEditorProps {
   statementId: string;
   creatorId: string;

--- a/components/statements/custom_editor/image_node_editor.tsx
+++ b/components/statements/custom_editor/image_node_editor.tsx
@@ -1,6 +1,11 @@
 import { useStatementToolsContext } from '@/contexts/StatementToolsContext';
 
-import { ImagePopoverEditor } from './image_popover_editor';
+import dynamic from 'next/dynamic';
+
+const ImagePopoverEditor = dynamic(
+  () => import('./image_popover_editor').then(mod => mod.ImagePopoverEditor),
+  { ssr: false }
+);
 export type NewImageData = {
   file?: File | undefined;
   src?: string;

--- a/components/statements/custom_editor/latex_node_editor.tsx
+++ b/components/statements/custom_editor/latex_node_editor.tsx
@@ -1,7 +1,12 @@
 import { useStatementContext } from '@/contexts/StatementBaseContext';
 import { useStatementToolsContext } from '@/contexts/StatementToolsContext';
 
-import { LatexPopoverEditor } from './latex_popover_editor';
+import dynamic from 'next/dynamic';
+
+const LatexPopoverEditor = dynamic(
+  () => import('./latex_popover_editor').then(mod => mod.LatexPopoverEditor),
+  { ssr: false }
+);
 
 export function LatexNodeEditor() {
   const { selectedNodePosition, latexPopoverOpen } = useStatementToolsContext();

--- a/components/statements/statement_details.tsx
+++ b/components/statements/statement_details.tsx
@@ -28,11 +28,24 @@ import { AspectRatio } from '../ui/aspect-ratio';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 
-import { EditorMenu } from './custom_editor/editor_menu';
-import HTMLSuperEditor from './custom_editor/html_super_editor';
+import dynamic from 'next/dynamic';
+
+const EditorMenu = dynamic(() =>
+  import('./custom_editor/editor_menu').then(mod => mod.EditorMenu),
+  { ssr: false }
+);
+const HTMLSuperEditor = dynamic(() => import('./custom_editor/html_super_editor'), {
+  ssr: false
+});
 import { ImageLightbox } from './custom_editor/image_lightbox';
-import { ImageNodeEditor } from './custom_editor/image_node_editor';
-import { LatexNodeEditor } from './custom_editor/latex_node_editor';
+const ImageNodeEditor = dynamic(
+  () => import('./custom_editor/image_node_editor').then(mod => mod.ImageNodeEditor),
+  { ssr: false }
+);
+const LatexNodeEditor = dynamic(
+  () => import('./custom_editor/latex_node_editor').then(mod => mod.LatexNodeEditor),
+  { ssr: false }
+);
 import { FootnoteList } from './footnote/footnote_list';
 import Byline from './byline';
 import StatementOptions from './statement_options';


### PR DESCRIPTION
## Summary
- dynamically load `HTMLSuperEditor` and `EditorMenu` in `StatementDetails`
- dynamically load heavy popovers in node editor components

## Testing
- `yarn lint`
- `yarn type-check` *(fails: Module '"kysely-codegen"' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_68889a96ba4c8329af5e346ff3505c84